### PR TITLE
Added CoAP Observe implementation on DeviceController

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This library is still in development. Current version: 0.3.0.x (x-build number, 
 Latest Gateway version tested and working - 1.3.14.
 
 - Get information on the gateway
-- Observe lights, groups and other resources (and in later versions get notified when they change)
+- Observe lights, groups and other resources
+- Get notified when lights, groups and other resources change
 - List all devices connected to gateway
 - List all lights and get attributes of lights (name, state, color temp, dimmer level etc)
 - Change attribute values of lights (currently only turn them on/off)

--- a/TradFriLibrary/TradFriCoap.cs
+++ b/TradFriLibrary/TradFriCoap.cs
@@ -127,6 +127,12 @@ namespace Tomidix.CSharpTradFriLibrary
             return _client.Put(request.Payload);
         }
 
+        public static CoapObserveRelation Observe(this CoapClient _client, TradFriRequest request, Action<Response> callback, Action<CoapClient.FailReason> error = null)
+        {
+            _client.UriPath = request.UriPath;
+            return _client.Observe(callback, error);
+        }
+
         [Obsolete("Method AcquireID() is too risky cause it extracts device id from its url string. You should use GetDevices() method which will already return the list of their IDs.")]
         public static long AcquireID(this WebLink _link)
         {


### PR DESCRIPTION
This method observes a device and takes actions on each device update, it also provides the TradFriDevice to callback function.
It is important to know that when the application using this method is being run by the debugger, there may be some troubles on mantaining the EndPoint's port open. This issue is related to Window's Firewall and does not occur when running a published client (it asks for network permissions). The time that the non ephemeral port will last open depends on Windows version.
[CoAP-CSharp Observe Notes](https://github.com/Com-AugustCellars/CoAP-CSharp/wiki/Observe-Example#notes)