### PR TITLE
Feature/#25 color wrapper fixes and additions

### DIFF
--- a/Tradfri/Controllers/DeviceController.cs
+++ b/Tradfri/Controllers/DeviceController.cs
@@ -79,7 +79,9 @@ namespace Tomidix.NetStandard.Tradfri.Controllers
         /// <returns></returns>
         public async Task SetColor(TradfriDevice device, int r, int g, int b)
         {
-            (int x, int y, int intensity) = ColorExtension.CalculateCIEFromRGB(r, g, b);
+            (int x, int y) = ColorExtension.CalculateCIEFromRGB(r, g, b);
+            int intensity = ColorExtension.CalculateIntensity(r, g, b);
+
             await SetColor(device.ID, x, y, intensity);
             if (HasLight(device))
             {

--- a/Tradfri/Controllers/DeviceController.cs
+++ b/Tradfri/Controllers/DeviceController.cs
@@ -73,12 +73,14 @@ namespace Tomidix.NetStandard.Tradfri.Controllers
         /// Changes the color of the light device
         /// </summary>
         /// <param name="device">A <see cref="TradfriDevice"/></param>
-        /// <param name="value">A color from the <see cref="TradfriColors"/> class</param>
+        /// <param name="r">Red component, 0-255</param>
+        /// <param name="g">Green component, 0-255</param>
+        /// <param name="b">Blue component, 0-255</param>
         /// <returns></returns>
         public async Task SetColor(TradfriDevice device, int r, int g, int b)
         {
-            (int x, int y) = ColorExtension.CalculateCIEFromRGB(r, g, b);
-            await SetColor(device.ID, x, y);
+            (int x, int y, int intensity) = ColorExtension.CalculateCIEFromRGB(r, g, b);
+            await SetColor(device.ID, x, y, intensity);
             if (HasLight(device))
             {
                 device.LightControl[0].ColorX = x;
@@ -92,7 +94,7 @@ namespace Tomidix.NetStandard.Tradfri.Controllers
         /// <param name="id">Id of the device</param>
         /// <param name="value">A color from the <see cref="TradfriColors"/> class</param>
         /// <returns></returns>
-        public async Task SetColor(long id, int x, int y)
+        public async Task SetColor(long id, int x, int y, int? intensity)
         {
             SwitchStateLightXYRequest set = new SwitchStateLightXYRequest()
             {
@@ -101,7 +103,8 @@ namespace Tomidix.NetStandard.Tradfri.Controllers
                     new SwitchStateLightXYRequestOption()
                     {
                         ColorX = x,
-                        ColorY = y
+                        ColorY = y,
+                        LightIntensity = intensity
                     }
                 }
             };

--- a/Tradfri/Controllers/DeviceController.cs
+++ b/Tradfri/Controllers/DeviceController.cs
@@ -100,8 +100,8 @@ namespace Tomidix.NetStandard.Tradfri.Controllers
                 {
                     new SwitchStateLightXYRequestOption()
                     {
-                        ColorX = x.ToString(),
-                        ColorY = y.ToString()
+                        ColorX = x,
+                        ColorY = y
                     }
                 }
             };
@@ -272,8 +272,8 @@ namespace Tomidix.NetStandard.Tradfri.Controllers
         [JsonProperty("5851")] //TradfriConstAttr.LightDimmer
         public int? LightIntensity { get; set; }
         [JsonProperty("5709")]
-        public string ColorX { get; set; }
+        public int ColorX { get; set; }
         [JsonProperty("5710")]
-        public string ColorY { get; set; }
+        public int ColorY { get; set; }
     }
 }

--- a/Tradfri/Controllers/DeviceController.cs
+++ b/Tradfri/Controllers/DeviceController.cs
@@ -92,7 +92,9 @@ namespace Tomidix.NetStandard.Tradfri.Controllers
         /// Changes the color of the light device
         /// </summary>
         /// <param name="id">Id of the device</param>
-        /// <param name="value">A color from the <see cref="TradfriColors"/> class</param>
+        /// <param name="x">X component of the color, 0-65535</param>
+        /// <param name="y">Y component of the color, 0-65535</param>
+        /// <param name="intensity">Optional Dimmer, 0-255</param>
         /// <returns></returns>
         public async Task SetColor(long id, int x, int y, int? intensity)
         {

--- a/Tradfri/Extensions/ColorExtension.cs
+++ b/Tradfri/Extensions/ColorExtension.cs
@@ -4,7 +4,7 @@ namespace Tomidix.NetStandard.Tradfri.Extensions
 {
     internal static class ColorExtension
     {
-        internal static (int, int, int) CalculateCIEFromRGB(int r, int g, int b)
+        internal static (int, int) CalculateCIEFromRGB(int r, int g, int b)
         {
             double red = GammaCorrection(r);
             double green = GammaCorrection(g);
@@ -23,9 +23,12 @@ namespace Tomidix.NetStandard.Tradfri.Extensions
             int xyX = (int)((x * 65535) + 0.5);
             int xyY = (int)((y * 65535) + 0.5);
 
-            int intensity = (int)(GetValue(r, g, b) * 254);
+            return (xyX, xyY);
+        }
 
-            return (xyX, xyY, intensity);
+        internal static int CalculateIntensity(int r, int g, int b)
+        {
+            return (int)(GetValue(r, g, b) * 254);
         }
 
         private static double GammaCorrection(double colorTone)
@@ -36,7 +39,7 @@ namespace Tomidix.NetStandard.Tradfri.Extensions
 
         private static double GetValue(int r, int g, int b)
         {
-            return Math.Max((double)r / 255.0, Math.Max((double)g / 255.0, (double)b / 255.0));
+            return Math.Max(r / 255.0, Math.Max(g / 255.0, b / 255.0));
         }
     }
 }

--- a/Tradfri/Extensions/ColorExtension.cs
+++ b/Tradfri/Extensions/ColorExtension.cs
@@ -4,7 +4,7 @@ namespace Tomidix.NetStandard.Tradfri.Extensions
 {
     internal static class ColorExtension
     {
-        internal static (int, int) CalculateCIEFromRGB(int r, int g, int b)
+        internal static (int, int, int) CalculateCIEFromRGB(int r, int g, int b)
         {
             double red = GammaCorrection(r);
             double green = GammaCorrection(g);
@@ -23,13 +23,20 @@ namespace Tomidix.NetStandard.Tradfri.Extensions
             int xyX = (int)((x * 65535) + 0.5);
             int xyY = (int)((y * 65535) + 0.5);
 
-            return (xyX, xyY);
+            int intensity = (int)(GetValue(r, g, b) * 254);
+
+            return (xyX, xyY, intensity);
         }
 
         private static double GammaCorrection(double colorTone)
         {
             // gamma correction
             return (colorTone > 0.04045) ? Math.Pow((colorTone + 0.055) / (1.0 + 0.055), 2.4) : (colorTone / 12.92);
+        }
+
+        private static double GetValue(int r, int g, int b)
+        {
+            return Math.Max((double)r / 255.0, Math.Max((double)g / 255.0, (double)b / 255.0));
         }
     }
 }


### PR DESCRIPTION
Fixed some issues resulting in the X and Y based color functions not working.

Added a simple intensity calculation from RGB values to control dimming - maximum of the individual components. The components are expected to fall between 0 and 255.
This should result in colors as bright as possible and works well enough - tested with Tradfri color bulbs.

There are however other ways to approach this. For instance [the eclipse/smarthome XY conversion](https://github.com/eclipse/smarthome/blob/master/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java#L378) includes the capital Y value in the brightness calculation. Maybe this results in more natural dimming curves but I'm not sure. It looks like the dimmer never goes full this way though. In any case it might be worth investigating.
