### PR TITLE
Fix missing restsharp reference

### DIFF
--- a/Tradfri/Tradfri.csproj
+++ b/Tradfri/Tradfri.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="ApiLibs" Version="1.43.0" />
     <PackageReference Include="Com.AugustCellars.CoAP" Version="1.6.0" />
+    <PackageReference Include="RestSharp" Version="106.6.9" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
When downloading a fresh copy of the repository I got an error on a missing reference for the RestSharp library.
This PR fixes this issue.